### PR TITLE
Remove x/net dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,4 @@ module github.com/pions/stun
 require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/net v0.0.0-20190119204137-ed066c81e75e
 )

--- a/go.sum
+++ b/go.sum
@@ -7,5 +7,3 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-golang.org/x/net v0.0.0-20190119204137-ed066c81e75e h1:MDa3fSUp6MdYHouVmCCNz/zaH2a6CRcxY3VhT/K3C5Q=
-golang.org/x/net v0.0.0-20190119204137-ed066c81e75e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/message.go
+++ b/message.go
@@ -3,9 +3,9 @@ package stun
 import (
 	"fmt"
 	"math/rand"
+	"net"
 
 	"github.com/pkg/errors"
-	"golang.org/x/net/ipv4"
 )
 
 // MessageClass of 0b00 is a request, a class of 0b01 is an
@@ -344,15 +344,14 @@ func (m *Message) Pack() []byte {
 }
 
 // BuildAndSend is building message, pack using attribute and send
-func BuildAndSend(conn *ipv4.PacketConn, addr *TransportAddr, class MessageClass, method Method, transactionID []byte, attrs ...Attribute) error {
-
+func BuildAndSend(conn net.PacketConn, addr *TransportAddr, class MessageClass, method Method, transactionID []byte, attrs ...Attribute) error {
 	rsp, err := Build(class, method, transactionID, attrs...)
 	if err != nil {
 		return err
 	}
 
 	b := rsp.Pack()
-	l, err := conn.WriteTo(b, nil, addr.Addr())
+	l, err := conn.WriteTo(b, addr.Addr())
 	if err != nil {
 		return errors.Wrap(err, "failed writing to socket")
 	}


### PR DESCRIPTION
Remove the dependency on x/net from `BuildAndSend` to allow
the caller to handle networking specifics.

I'll make a corresponding PR for pions/turn.